### PR TITLE
Added giphbot script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SafeBot",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "scripts": {
     "test": "echo \"no tests to run\""
   },

--- a/scripts/giphy.coffee
+++ b/scripts/giphy.coffee
@@ -1,0 +1,27 @@
+# Commands:
+#   hubot giphy <term> - Returns a randomly selected gif from a search of the giphy api for <term>
+    
+giphy =
+  api_key: process.env.HUBOT_GIPHY_API_KEY
+  api_url: 'http://api.giphy.com/v1'
+    
+  
+  search: (msg, q) ->
+    endpoint = '/gifs/search'
+    url = "#{giphy.api_url}#{endpoint}"
+    msg.http(url)
+      .query
+        api_key: giphy.api_key
+        q: q
+      .get() (err, res, body) ->
+        parseBody = JSON.parse(body)
+        data = parseBody?.data ? []
+        if data.length
+          img_obj = msg.random data
+          msg.send(img_obj.images.original.url)
+        else
+          msg.send "No results found for #{q}"
+          
+module.exports = (robot) ->
+  robot.respond /giphy (.*)$/i, (msg) ->
+    giphy.search msg, msg.match[1]


### PR DESCRIPTION
this will allow Hubot to use command `giphy {search term}` to supply animated gifs in our flowdock
### Testing
1. Checkout this PR
2. run `HUBOT_GIPHY_API_KEY=dc6zaTOxFJmzC bin/hubot`
3. See that `hubot help` lists the giphy command
4. See that `hubot giphy photo` results in hubot replying with a giphy image
